### PR TITLE
Use auto-generated statement id for lambda perm

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -62,7 +62,7 @@ workflows:
           requires:
             - lint-11
             - lint-12
-          version: "1.0.0"
+          version: "1.0.1"
           filters:
             branches:
               only:

--- a/main.tf
+++ b/main.tf
@@ -47,7 +47,6 @@ data "template_file" "compute_queue_backlog" {
 }
 
 resource "aws_lambda_permission" "compute_queue_backlog" {
-  statement_id  = "AllowExecutionFromCloudWatch"
   action        = "lambda:InvokeFunction"
   function_name = "${data.aws_lambda_function.compute_queue_backlog.function_name}"
   principal     = "events.amazonaws.com"


### PR DESCRIPTION
Hardcoded statement id can cause conflict with non-Terraform
permissions, as it is a common statement id.