### PR TITLE
PLAT-2162 Upgrade to version 2.0.0

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,9 +1,9 @@
 version: 2.1
 
 jobs:
-  lint-12:
+  lint:
     docker:
-      - image: hashicorp/terraform:0.12.2
+      - image: hashicorp/terraform:0.12.5
     steps:
       - checkout
       - run:
@@ -15,20 +15,6 @@ jobs:
       - run:
           name: Validate
           command: terraform validate
-  lint-11:
-    docker:
-      - image: hashicorp/terraform:0.11.11
-    steps:
-      - checkout
-      - run:
-          name: Init
-          command: terraform init -backend=false
-      - run:
-          name: Lint
-          command: terraform fmt -check=true -diff=true
-      - run:
-          name: Validate
-          command: terraform validate -check-variables=false
   tag:
     machine: true
     parameters:
@@ -56,13 +42,11 @@ workflows:
   version: 2
   primary:
     jobs:
-      - lint-11
-      - lint-12
+      - lint
       - tag:
           requires:
-            - lint-11
-            - lint-12
-          version: "1.0.1"
+            - lint
+          version: "2.0.0"
           filters:
             branches:
               only:

--- a/.gitignore
+++ b/.gitignore
@@ -27,3 +27,5 @@ override.tf.json
 
 # Include tfplan files to ignore the plan output of command: terraform plan -out=tfplan
 # example: *tfplan*
+
+*.zip

--- a/examples/lambda-function/README.md
+++ b/examples/lambda-function/README.md
@@ -1,0 +1,5 @@
+# Compute Queue Backlog Lambda Function Example
+
+This folder shows an example of Terraform code that uses the lambda-function module
+to deploy a Compute Queue Backlog lambda in AWS. You can then create test events
+against this function to see how it works.

--- a/examples/lambda-function/main.tf
+++ b/examples/lambda-function/main.tf
@@ -1,0 +1,14 @@
+terraform {
+  required_version = ">= 0.12"
+}
+
+module "compute_queue_backlog" {
+  source = "../../modules/lambda-function"
+
+  name = "compute-queue-backlog-example"
+
+  log_level = "DEBUG"
+
+  dd_api_key = var.dd_api_key
+  dd_app_key = var.dd_app_key
+}

--- a/examples/lambda-function/outputs.tf
+++ b/examples/lambda-function/outputs.tf
@@ -1,14 +1,14 @@
 output "arn" {
-  value       = aws_lambda_function.compute_queue_backlog.arn
+  value       = "${module.compute_queue_backlog.arn}"
   description = "This is compute queue backlog lambda's unqualified arn."
 }
 
 output "name" {
-  value       = aws_lambda_function.compute_queue_backlog.function_name
+  value       = "${module.compute_queue_backlog.name}"
   description = "This is compute queue backlog lambda's function name."
 }
 
 output "execution_role_arn" {
-  value       = element(concat(aws_iam_role.compute_queue_backlog.*.arn, list("")), 0)
+  value       = "${module.compute_queue_backlog.execution_role_arn}"
   description = "This is the ARN for the execution role that was created for the lambda. It will be empty if you supplied your own."
 }

--- a/examples/lambda-function/variables.tf
+++ b/examples/lambda-function/variables.tf
@@ -1,0 +1,9 @@
+variable "dd_api_key" {
+  description = "The API key for the lambda to use when communicating with DataDog. Required to use the lambda with DataDog metrics."
+  default     = ""
+}
+
+variable "dd_app_key" {
+  description = "The Application key for the lambda to use when reading metrics from DataDog. Required to use the lambda with DataDog metrics."
+  default     = ""
+}

--- a/examples/sqs-scaling/README.md
+++ b/examples/sqs-scaling/README.md
@@ -1,0 +1,12 @@
+# Example of scaling an ECS service based on an SQS queue
+
+This folder shows an example of Terraform code that uses the lambda-function module
+and top-level terraform-aws-ecs-queue-backlog-autoscaling module to deploy a
+Compute Queue Backlog lambda in AWS and then create autoscaling policies,
+CloudWatch Alarms, and CloudWatch Rules that use the lambda output to trigger
+scaling actions on a service of your choice based on the queue backlog for an
+SQS queue of your choice.
+
+## Requirements
+* Existing AWS account with an ECS cluster and service
+* Existing SQS queue on the same AWS account as the ECS cluster

--- a/examples/sqs-scaling/main.tf
+++ b/examples/sqs-scaling/main.tf
@@ -1,0 +1,50 @@
+terraform {
+  required_version = ">= 0.12"
+}
+
+data "aws_sqs_queue" "this" {
+  name = var.queue_name
+}
+
+module "compute_queue_backlog_lambda" {
+  source = "../../modules/lambda-function"
+
+  name = "compute-queue-backlog-full-example"
+
+  log_level = "DEBUG"
+}
+
+module "compute_queue_backlog" {
+  source = "../.."
+
+  cluster_name = var.cluster_id
+
+  service_name             = var.service_name
+  service_max_capacity     = var.service_max_capacity
+  service_min_capacity     = var.service_min_capacity
+  service_est_msgs_per_sec = var.service_est_msgs_per_sec
+
+  queue_name                 = var.queue_name
+  queue_backlog_target_value = var.queue_backlog_target_value
+
+  lambda_name = module.compute_queue_backlog_lambda.name
+}
+
+resource "aws_sqs_queue_policy" "this" {
+  queue_url = data.aws_sqs_queue.this.url
+  policy    = data.aws_iam_policy_document.sqs.json
+}
+
+data "aws_iam_policy_document" "sqs" {
+  statement {
+    effect    = "Allow"
+    actions   = ["sqs:GetQueueUrl", "sqs:GetQueueAttributes"]
+    resources = [data.aws_sqs_queue.this.arn]
+
+    principals {
+      identifiers = [module.compute_queue_backlog_lambda.execution_role_arn]
+
+      type = "AWS"
+    }
+  }
+}

--- a/examples/sqs-scaling/outputs.tf
+++ b/examples/sqs-scaling/outputs.tf
@@ -1,0 +1,9 @@
+output "lambda" {
+  value       = module.compute_queue_backlog_lambda
+  description = "Information about the lambda function."
+}
+
+output "aws_cloudwatch_event_rule_arn" {
+  value       = module.compute_queue_backlog.aws_cloudwatch_event_rule_arn
+  description = "ARN for the CloudWatch Event Rule that invokes the compute queue backlog lambda at a user-defined interval"
+}

--- a/examples/sqs-scaling/variables.tf
+++ b/examples/sqs-scaling/variables.tf
@@ -1,0 +1,33 @@
+variable "queue_name" {
+  description = "SQS queue name."
+}
+
+variable "queue_backlog_target_value" {
+  description = "Queue backlog (in seconds) to maintain for the service when under maximum load."
+  default     = "600"
+}
+
+variable "cluster_id" {
+  description = "ECS cluster id."
+  default     = "default"
+}
+
+variable "service_name" {
+  description = "ECS service name."
+}
+
+variable "service_max_capacity" {
+  description = "Maximum number of tasks that the autoscaling policy can set for the service."
+  default     = "1"
+}
+
+variable "service_min_capacity" {
+  description = "Minimum number of tasks that the autoscaling policy can set for the service."
+  default     = "0"
+}
+
+# Queue backlog-based autoscaling configuration
+variable "service_est_msgs_per_sec" {
+  description = "Service to non-negative integer that represents the estimated number of messages the service can consume from its queue in one second."
+  default     = "1"
+}

--- a/files/cw_event_target_args.json.tpl
+++ b/files/cw_event_target_args.json.tpl
@@ -1,4 +1,8 @@
 {
+  "metric_provider": "${metric_provider}",
+  "metric_name": "${metric_name}",
+  "metric_filter": "${metric_filter}",
+  "metric_aggregate": "${metric_aggregate}",
   "cluster_name": "${cluster_name}",
   "service_name": "${service_name}",
   "queue_name": "${queue_name}",

--- a/main.tf
+++ b/main.tf
@@ -1,56 +1,60 @@
 terraform {
-  required_version = ">= 0.11.11"
+  required_version = ">= 0.12"
 }
 
 # Create ECS service autoscaling policies
 module "autoscale_service" {
   source = "./modules/service-autoscaling"
 
-  cluster_name = "${var.cluster_name}"
-  service_name = "${var.service_name}"
-  queue_name   = "${var.queue_name}"
+  cluster_name = var.cluster_name
+  service_name = var.service_name
+  queue_name   = var.queue_name
 
-  max_capacity = "${var.service_max_capacity}"
-  min_capacity = "${var.service_min_capacity}"
+  max_capacity = var.service_max_capacity
+  min_capacity = var.service_min_capacity
 
-  target_value = "${var.queue_backlog_target_value}"
+  target_value = var.queue_backlog_target_value
 }
 
 data "aws_lambda_function" "compute_queue_backlog" {
-  function_name = "${var.lambda_name}"
+  function_name = var.lambda_name
 }
 
 # Create cloudwatch event resources to invoke the compute-queue-backlog lambda
 resource "aws_cloudwatch_event_rule" "compute_queue_backlog" {
   name                = "${data.aws_lambda_function.compute_queue_backlog.function_name}-${var.service_name}"
   description         = "Schedule execution of ${data.aws_lambda_function.compute_queue_backlog.function_name} to compute queue backlog metrics for ${var.service_name} ${var.queue_name} queue."
-  schedule_expression = "${var.lambda_invocation_interval}"
+  schedule_expression = var.lambda_invocation_interval
 }
 
 resource "aws_cloudwatch_event_target" "compute_queue_backlog" {
-  rule      = "${aws_cloudwatch_event_rule.compute_queue_backlog.name}"
+  rule      = aws_cloudwatch_event_rule.compute_queue_backlog.name
   target_id = "${data.aws_lambda_function.compute_queue_backlog.function_name}-${var.service_name}"
-  arn       = "${data.aws_lambda_function.compute_queue_backlog.arn}"
-  input     = "${data.template_file.compute_queue_backlog.rendered}"
+  arn       = data.aws_lambda_function.compute_queue_backlog.arn
+  input     = data.template_file.compute_queue_backlog.rendered
 }
 
 data "template_file" "compute_queue_backlog" {
   template = "${file("${path.module}/files/cw_event_target_args.json.tpl")}"
 
   vars = {
-    cluster_name               = "${var.cluster_name}"
-    service_name               = "${var.service_name}"
-    queue_name                 = "${var.queue_name}"
-    queue_owner_aws_account_id = "${var.queue_owner_aws_account_id != "" ? var.queue_owner_aws_account_id : data.aws_caller_identity.current.account_id}"
-    est_msgs_per_sec           = "${var.service_est_msgs_per_sec}"
+    cluster_name               = var.cluster_name
+    service_name               = var.service_name
+    metric_provider            = var.metric_provider
+    metric_name                = var.metric_name
+    metric_filter              = var.metric_filter
+    metric_aggregate           = var.metric_aggregate
+    queue_name                 = var.queue_name
+    queue_owner_aws_account_id = var.queue_owner_aws_account_id != "" ? var.queue_owner_aws_account_id : data.aws_caller_identity.current.account_id
+    est_msgs_per_sec           = var.service_est_msgs_per_sec
   }
 }
 
 resource "aws_lambda_permission" "compute_queue_backlog" {
   action        = "lambda:InvokeFunction"
-  function_name = "${data.aws_lambda_function.compute_queue_backlog.function_name}"
+  function_name = data.aws_lambda_function.compute_queue_backlog.function_name
   principal     = "events.amazonaws.com"
-  source_arn    = "${aws_cloudwatch_event_rule.compute_queue_backlog.arn}"
+  source_arn    = aws_cloudwatch_event_rule.compute_queue_backlog.arn
 }
 
 data "aws_caller_identity" "current" {}

--- a/modules/lambda-function/README.md
+++ b/modules/lambda-function/README.md
@@ -31,15 +31,31 @@ The lambda function computes QueueBacklog and QueueRequiresConsumer CloudWatch
 metrics via [compute_queue_backlog.py](compute_queue_backlog.py). The function
 must take the following parameters as its input.
 
+#### Parameters
 * cluster_name - The name of the ECS cluster
 * service_name - The name of the ECS service that consumes from the target queue
-* queue_owner_aws_account_id - The AWS account id that provides the target queue
 * queue_name - The target queue name
+* metric_provider - The service we use to obtain metric data for the queue. (Valid values: `AWS/SQS` [default] and `DATADOG`).
+* metric_name - The name of the metric the lambda uses to derive the queue backlog value. (Default: `ApproximateNumberOfMessages`).
+* est_msgs_per_sec - Non-negative integer that represents the estimated number of messages the service can consume from the target queue in one second. (Default: `1`).
 
-Optional parameters are as follows.
-* est_msgs_per_sec - Non-negative integer that represents the estimated number of messages the service can consume from the target queue in one second. Default: 1.
+##### DataDog
+* metric_filter - The filter condition to apply to the metric query. (Default: `*`).
+* metric_aggregate - The aggregate function to use for metric rollup. (Valid values: `min`, `max` [default], `avg`, `sum`).
 
-The lambda arn is exported as `lambda_arn`.
+##### AWS/SQS
+* queue_owner_aws_account_id - The AWS account id that provides the target queue.
+
+#### Environment
+* LOG_LEVEL - Log level to use for Lambda logs. Accepts the standard Python log levels. (Default: `INFO`).
+
+##### DataDog
+* DD_API_KEY - The API key for the lambda to use when communicating with DataDog.
+* DD_APP_KEY - The Application key for the lambda to use when reading metrics from DataDog.
+
+#### Assumptions
+* An increase in the metric value must signify an increase in pressure on the queue.
+* A metric value of `0` must signify that the queue is empty.
 
 
 ### Roles and Permissions

--- a/modules/lambda-function/variables.tf
+++ b/modules/lambda-function/variables.tf
@@ -3,7 +3,27 @@ variable "name" {
   default     = "compute-queue-backlog"
 }
 
+variable "grant_access_to_sqs" {
+  description = "Set to 'true' (the default) to grant the necessary permissions to read from SQS queues."
+  default     = true
+}
+
+variable "log_level" {
+  description = "Log level to use for Lambda logs. Accepts the standard Python log levels."
+  default     = "INFO"
+}
+
+variable "dd_api_key" {
+  description = "The API key for the lambda to use when communicating with DataDog. Required to use the lambda with DataDog metrics."
+  default     = ""
+}
+
+variable "dd_app_key" {
+  description = "The Application key for the lambda to use when reading metrics from DataDog. Required to use the lambda with DataDog metrics."
+  default     = ""
+}
+
 variable "execution_role_arn" {
-  description = "IAM role arn to use for lambda execution. If not supplied, this module will create a role with necessary permissions. These permissions are 'cloudwatch:PutMetricData', 'ecs:DescribeServices', 'sqs:GetQueueUrl', 'sqs:GetQueueAttributes', 'logs:CreateLogGroup', 'logs:CreateLogStream', and 'logs:PutLogEvents'."
+  description = "IAM role arn to use for lambda execution. If not supplied, this module will create a role with necessary permissions. These permissions are 'cloudwatch:PutMetricData', 'ecs:DescribeServices', 'logs:CreateLogGroup', 'logs:CreateLogStream', and 'logs:PutLogEvents'. If 'grant_access_to_sqs' is 'true', 'sqs:GetQueueUrl' and 'sqs:GetQueueAttributes' are also added."
   default     = ""
 }

--- a/modules/service-autoscaling/outputs.tf
+++ b/modules/service-autoscaling/outputs.tf
@@ -1,9 +1,9 @@
 output "queue_requires_consumer_scaling_policy_arn" {
-  value       = "${aws_appautoscaling_policy.queue_requires_consumer_scaling_policy.arn}"
+  value       = aws_appautoscaling_policy.queue_requires_consumer_scaling_policy.arn
   description = "ARN for the StepScaling policy tied to QueueRequiresConsumer metric."
 }
 
 output "queue_backlog_scaling_policy_arn" {
-  value       = "${aws_appautoscaling_policy.queue_backlog_scaling_policy.arn}"
+  value       = aws_appautoscaling_policy.queue_backlog_scaling_policy.arn
   description = "ARN for the TargetTrackingScaling policy tied to QueueBacklog metric."
 }

--- a/outputs.tf
+++ b/outputs.tf
@@ -1,4 +1,4 @@
 output "aws_cloudwatch_event_rule_arn" {
-  value       = "${aws_cloudwatch_event_rule.compute_queue_backlog.arn}"
+  value       = aws_cloudwatch_event_rule.compute_queue_backlog.arn
   description = "ARN for the CloudWatch Event Rule that invokes the compute queue backlog lambda at a user-defined interval."
 }

--- a/variables.tf
+++ b/variables.tf
@@ -21,13 +21,18 @@ variable "service_est_msgs_per_sec" {
   description = "Non-negative integer that represents the estimated number of messages the service can consume from its queue in one second."
 }
 
-variable "queue_name" {
-  description = "Name of the queue to compute QueueBacklog metric for."
+variable "metric_provider" {
+  description = "Service that provides metric data required to compute the queue backlog value. Valid values are 'AWS/SQS' and 'DATADOG'."
+  default     = "AWS/SQS"
 }
 
-variable "queue_owner_aws_account_id" {
-  description = "AWS account id that provides the queue. If not provided, will use the caller's account id."
-  default     = ""
+variable "metric_name" {
+  description = "The name of the metric the lambda uses to derive the queue backlog value."
+  default     = "ApproximateNumberOfMessages"
+}
+
+variable "queue_name" {
+  description = "Name of the queue to compute QueueBacklog metric for. For the 'AWS/SQS' metric provider, the name must be the name of the SQS queue. It can be any value you wish for other metric providers."
 }
 
 variable "queue_backlog_target_value" {
@@ -43,4 +48,35 @@ variable "lambda_name" {
 variable "lambda_invocation_interval" {
   description = "Rate or cron expression to determine the interval for QueueBacklog metric refresh."
   default     = "rate(1 minute)"
+}
+
+
+# AWS/SQS-specific configuration
+
+variable "queue_owner_aws_account_id" {
+  description = "AWS account id that provides the queue. If not provided, will use the caller's account id. Only valid for 'AWS/SQS' metric provider."
+  default     = ""
+}
+
+
+# DataDog-specific configuration
+
+variable "metric_filter" {
+  description = "The filter condition to apply to the metric query. For DataDog, this is equivalent to the 'over' section in Metrics Explorer."
+  default     = ""
+}
+
+variable "metric_aggregate" {
+  description = "The aggregate function to use for metric rollup. Valid values are 'min', 'max', 'avg', and 'sum'."
+  default     = ""
+}
+
+variable "dd_api_key" {
+  description = "The API key for the lambda to use when communicating with DataDog. Required if the metric_provider is 'DATADOG'."
+  default     = ""
+}
+
+variable "dd_app_key" {
+  description = "The Application key for the lambda to use when reading metrics from DataDog. Required if the metric_provider is 'DATADOG'."
+  default     = ""
 }


### PR DESCRIPTION
* Update minimum Terraform version to 0.12.x
* Support DataDog metrics as data source for the queue backlog metric
* Add example of lambda-function usage.
* Add example of autoscaling + lambda-function working together.

PLAT-2162