### PR TITLE
Ensure ENABLE_DATADOG_JSON_FORMATTER = true

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -46,7 +46,7 @@ workflows:
       - tag:
           requires:
             - lint
-          version: "2.1.0"
+          version: "2.1.1"
           filters:
             branches:
               only:

--- a/modules/lambda-function/main.tf
+++ b/modules/lambda-function/main.tf
@@ -32,9 +32,10 @@ resource "aws_lambda_function" "compute_queue_backlog" {
 
   environment {
     variables = {
-      LOG_LEVEL  = var.log_level
-      DD_API_KEY = var.dd_api_key
-      DD_APP_KEY = var.dd_app_key
+      LOG_LEVEL                     = var.log_level
+      DD_API_KEY                    = var.dd_api_key
+      DD_APP_KEY                    = var.dd_app_key
+      ENABLE_DATADOG_JSON_FORMATTER = var.enable_datadog_json_formatter
     }
   }
 

--- a/modules/lambda-function/variables.tf
+++ b/modules/lambda-function/variables.tf
@@ -28,6 +28,11 @@ variable "dd_app_key" {
   default     = ""
 }
 
+variable "enable_datadog_json_formatter" {
+  description = "If Muselog is available to the lambda function, this setting will ensure that its logs are in JSON format for easier parsing by DataDog logs."
+  default     = "true"
+}
+
 variable "execution_role_arn" {
   description = "IAM role arn to use for lambda execution. If not supplied, this module will create a role with necessary permissions. These permissions are 'cloudwatch:PutMetricData', 'ecs:DescribeServices', 'logs:CreateLogGroup', 'logs:CreateLogStream', and 'logs:PutLogEvents'. If 'grant_access_to_sqs' is 'true', 'sqs:GetQueueUrl' and 'sqs:GetQueueAttributes' are also added."
   default     = ""


### PR DESCRIPTION
This env var is required to have the lambda log in json format if
muselog is available.