### PR TITLE
PLAT-2254 Support SQS metric_name & metric_provider defaults

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -46,7 +46,7 @@ workflows:
       - tag:
           requires:
             - lint
-          version: "2.1.1"
+          version: "2.1.2"
           filters:
             branches:
               only:


### PR DESCRIPTION
We must support existing cloudwatch rules that do not set metric_name or metric_provider.

PLAT-2254