### PR TITLE
PLAT-2406 Allow opt-out of autoscaling target creation

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -46,7 +46,7 @@ workflows:
       - tag:
           requires:
             - lint
-          version: "2.1.2"
+          version: "2.2.0"
           filters:
             branches:
               only:

--- a/modules/service-autoscaling/variables.tf
+++ b/modules/service-autoscaling/variables.tf
@@ -7,6 +7,11 @@ variable "service_name" {
   description = "ECS service name"
 }
 
+variable "create_appautoscaling_target" {
+  description = "Flag to indicate if the module will create an appautoscaling_target. If false, module assumes a target already exists."
+  default     = true
+}
+
 variable "max_capacity" {
   description = "Maximum number of tasks that the autoscaling policy can set for the service."
   default     = 1


### PR DESCRIPTION
To allow multiple scaling policies per service, we need to allow the
user to create their own autoscaling target.

PLAT-2406