### PR TITLE
PLAT-2448 Add support for QueueRequiresConsumer alarm prefix

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -46,7 +46,7 @@ workflows:
       - tag:
           requires:
             - lint
-          version: "2.2.0"
+          version: "2.2.1"
           filters:
             branches:
               only:

--- a/modules/service-autoscaling/main.tf
+++ b/modules/service-autoscaling/main.tf
@@ -79,7 +79,7 @@ resource "aws_appautoscaling_policy" "queue_requires_consumer_scaling_policy" {
 }
 
 resource "aws_cloudwatch_metric_alarm" "queue_requires_consumer_alarm" {
-  alarm_name          = "ecs-${var.service_name}-${var.queue_name}-queue-requires-consumer"
+  alarm_name          = "${var.queue_requires_consumer_alarm_prefix}ecs-${var.service_name}-${var.queue_name}-queue-requires-consumer"
   alarm_description   = "Managed by Terraform"
   alarm_actions       = [aws_appautoscaling_policy.queue_requires_consumer_scaling_policy.arn]
   comparison_operator = var.queue_requires_consumer_alarm_comparison_op

--- a/modules/service-autoscaling/variables.tf
+++ b/modules/service-autoscaling/variables.tf
@@ -51,6 +51,11 @@ variable "rampup_capacity" {
   default     = 1
 }
 
+variable "queue_requires_consumer_alarm_prefix" {
+  description = "Prefix to apply to the QueueRequiresConsumer CloudWatch alarm, which may be necessary to ensure uniqueness in multi-environment deployments."
+  default     = ""
+}
+
 variable "queue_requires_consumer_alarm_period" {
   description = "Number of seconds to aggregate QueueRequiresConsumer metric before testing against the alarm threshold."
   default     = 60


### PR DESCRIPTION
Adds `queue_requires_consumer_alarm_prefix` variable to support multi-environment deployments.

PLAT-2448