### PR TITLE
PLAT-3136 Ensure as objs recreated when service recreated

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,7 +3,7 @@ version: 2.1
 jobs:
   lint:
     docker:
-      - image: hashicorp/terraform:0.12.5
+      - image: hashicorp/terraform:0.12.26
     steps:
       - checkout
       - run:
@@ -46,7 +46,7 @@ workflows:
       - tag:
           requires:
             - lint
-          version: "2.3.1"
+          version: "2.3.2"
           filters:
             branches:
               only:

--- a/examples/sqs-scaling/main.tf
+++ b/examples/sqs-scaling/main.tf
@@ -2,8 +2,46 @@ terraform {
   required_version = ">= 0.12"
 }
 
-data "aws_sqs_queue" "this" {
+resource "aws_sqs_queue" "main" {
+  count = var.create_queue ? 1 : 0
+
   name = var.queue_name
+}
+
+data "aws_sqs_queue" "main" {
+  count = var.create_queue ? 0 : 1
+
+  name = var.queue_name
+}
+
+resource "aws_ecs_task_definition" "main" {
+  count = var.create_service ? 1 : 0
+
+  family                   = var.service_name
+  requires_compatibilities = ["EC2"]
+  cpu                      = 1024
+  memory                   = 128
+
+  container_definitions = jsonencode([
+    {
+      name      = "test"
+      image     = "busybox"
+      essential = true
+      command   = ["echo", "yes"]
+    }
+  ])
+}
+
+resource "aws_ecs_service" "main" {
+  count = var.create_service ? 1 : 0
+
+  name            = var.service_name
+  task_definition = aws_ecs_task_definition.main[count.index].arn
+  cluster         = var.cluster_id
+
+  lifecycle {
+    ignore_changes = [desired_count]
+  }
 }
 
 module "compute_queue_backlog_lambda" {
@@ -28,10 +66,12 @@ module "compute_queue_backlog" {
   queue_backlog_target_value = var.queue_backlog_target_value
 
   lambda_name = module.compute_queue_backlog_lambda.name
+
+  depends_on_service = var.create_service ? aws_ecs_service.main[0] : null
 }
 
-resource "aws_sqs_queue_policy" "this" {
-  queue_url = data.aws_sqs_queue.this.url
+resource "aws_sqs_queue_policy" "main" {
+  queue_url = var.create_queue ? aws_sqs_queue.main[0].id : data.aws_sqs_queue.main[0].url
   policy    = data.aws_iam_policy_document.sqs.json
 }
 
@@ -39,7 +79,7 @@ data "aws_iam_policy_document" "sqs" {
   statement {
     effect    = "Allow"
     actions   = ["sqs:GetQueueUrl", "sqs:GetQueueAttributes"]
-    resources = [data.aws_sqs_queue.this.arn]
+    resources = [var.create_queue ? aws_sqs_queue.main[0].arn : data.aws_sqs_queue.main[0].arn]
 
     principals {
       identifiers = [module.compute_queue_backlog_lambda.execution_role_arn]

--- a/examples/sqs-scaling/variables.tf
+++ b/examples/sqs-scaling/variables.tf
@@ -1,5 +1,11 @@
+variable "create_queue" {
+  description = "Create the queue. Otherwise, assume it exists."
+  default     = false
+}
+
 variable "queue_name" {
   description = "SQS queue name."
+  default     = "ecs-queue-backlog-example"
 }
 
 variable "queue_backlog_target_value" {
@@ -12,8 +18,14 @@ variable "cluster_id" {
   default     = "default"
 }
 
+variable "create_service" {
+  description = "Create the ECS service with a dummy task definition. Otherwise, assume it exists."
+  default     = false
+}
+
 variable "service_name" {
   description = "ECS service name."
+  default     = "ecs-queue-backlog-example"
 }
 
 variable "service_max_capacity" {

--- a/main.tf
+++ b/main.tf
@@ -16,6 +16,8 @@ module "autoscale_service" {
   target_value = var.queue_backlog_target_value
 
   queue_requires_consumer_alarm_tags = var.queue_requires_consumer_alarm_tags
+
+  depends_on_service = var.depends_on_service
 }
 
 data "aws_lambda_function" "compute_queue_backlog" {

--- a/modules/lambda-function/main.tf
+++ b/modules/lambda-function/main.tf
@@ -85,8 +85,8 @@ data "aws_iam_policy_document" "compute_queue_backlog_trust_relationship" {
 resource "aws_iam_role_policy" "compute_queue_backlog" {
   count  = var.execution_role_arn == "" ? 1 : 0
   name   = "${var.name}-role-policy"
-  role   = "${element(concat(aws_iam_role.compute_queue_backlog.*.name, list("")), 0)}"
-  policy = "${data.aws_iam_policy_document.compute_queue_backlog.json}"
+  role   = element(concat(aws_iam_role.compute_queue_backlog.*.name, list("")), 0)
+  policy = data.aws_iam_policy_document.compute_queue_backlog.json
 }
 
 resource "aws_iam_role_policy" "compute_queue_backlog_sqs" {

--- a/modules/service-autoscaling/main.tf
+++ b/modules/service-autoscaling/main.tf
@@ -3,8 +3,12 @@ terraform {
 }
 
 locals {
+  cluster_name = var.cluster_name != "" ? var.cluster_name : "default"
+}
+
+locals {
   appautoscaling_target_info = {
-    resource_id        = "service/${var.cluster_name}/${var.service_name}"
+    resource_id        = "service/${local.cluster_name}/${var.depends_on_service != null ? split("/", var.depends_on_service.id)[2] : var.service_name}"
     scalable_dimension = "ecs:service:DesiredCount"
     service_namespace  = "ecs"
   }

--- a/modules/service-autoscaling/variables.tf
+++ b/modules/service-autoscaling/variables.tf
@@ -80,3 +80,9 @@ variable "queue_requires_consumer_alarm_tags" {
   description = "Map of AWS tags to add to the alarm. Note that the 'Name' tag is always added, and is the same as the value of the resource's 'name' attribute by default. The 'Description' tag is added as well."
   default     = {}
 }
+
+variable "depends_on_service" {
+  description = "aws_ecs_service object that you can pass to the module to ensure autoscaling resources are recreated properly."
+  type        = any
+  default     = null
+}

--- a/variables.tf
+++ b/variables.tf
@@ -60,6 +60,12 @@ variable "queue_requires_consumer_alarm_tags" {
   default     = {}
 }
 
+variable "depends_on_service" {
+  description = "aws_ecs_service object that you can pass to the module to ensure resources are recreated properly on service recreate."
+  type        = any
+  default     = null
+}
+
 
 # AWS/SQS-specific configuration
 


### PR DESCRIPTION
Adds `depends_on_service`, which takes a service object to ensure that several autoscaling resources are recreated when the service is recreated. Without this, recreating the service will cause a syntax error in the autoscaling module due to a state <-> reality mismatch for the appautoscaling target and policies, as AWS removes them automatically when the service is destroyed.

I have made this variable optional to maintain backwards compatibility, but anyone looking to take advantage of app autoscaling support with a Terraform-managed service should use the variable. You can find an example of its use in examples/sqs-scaling.

PLAT-3136