### PR TITLE
PLAT-2381 Add SSM Parameter Store-backed datadog keys

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -46,7 +46,7 @@ workflows:
       - tag:
           requires:
             - lint
-          version: "2.3.2"
+          version: "2.4.0"
           filters:
             branches:
               only:

--- a/modules/lambda-function/main.tf
+++ b/modules/lambda-function/main.tf
@@ -34,7 +34,9 @@ resource "aws_lambda_function" "compute_queue_backlog" {
     variables = {
       LOG_LEVEL                     = var.log_level
       DD_API_KEY                    = var.dd_api_key
+      DD_API_KEY_PATH               = var.dd_api_key_path
       DD_APP_KEY                    = var.dd_app_key
+      DD_APP_KEY_PATH               = var.dd_app_key_path
       ENABLE_DATADOG_JSON_FORMATTER = var.enable_datadog_json_formatter
     }
   }

--- a/modules/lambda-function/variables.tf
+++ b/modules/lambda-function/variables.tf
@@ -28,8 +28,18 @@ variable "dd_api_key" {
   default     = ""
 }
 
+variable "dd_api_key_path" {
+  description = "ECS parameter store path where the DataDog API key is found. This is preferred over dd_api_key."
+  default     = ""
+}
+
 variable "dd_app_key" {
   description = "The Application key for the lambda to use when reading metrics from DataDog. Required to use the lambda with DataDog metrics."
+  default     = ""
+}
+
+variable "dd_app_key_path" {
+  description = "ECS parameter store path where the DataDog APP key is found. This is preferred over dd_app_key."
   default     = ""
 }
 

--- a/variables.tf
+++ b/variables.tf
@@ -86,13 +86,3 @@ variable "metric_aggregate" {
   description = "The aggregate function to use for metric rollup. Valid values are 'min', 'max', 'avg', and 'sum'."
   default     = ""
 }
-
-variable "dd_api_key" {
-  description = "The API key for the lambda to use when communicating with DataDog. Required if the metric_provider is 'DATADOG'."
-  default     = ""
-}
-
-variable "dd_app_key" {
-  description = "The Application key for the lambda to use when reading metrics from DataDog. Required if the metric_provider is 'DATADOG'."
-  default     = ""
-}


### PR DESCRIPTION
Add `DD_API_KEY_PATH` and `DD_APP_KEY_PATH` environment variables for compute-queue-backlog lambda function. If set, the function will use the variable values as paths to SSM parameter store, and fetch the actual key contents at that path. The code assumes the key contents are encrypted.

PLAT-2381